### PR TITLE
fix(patcher): SpreadsheetLoader CSV 조회 키 보호 — 무장 포인트 0 버그 수정

### DIFF
--- a/patches/exclusions.json
+++ b/patches/exclusions.json
@@ -20,7 +20,10 @@
 
     "com/fs/starfarer/api/impl/campaign/CoreLifecyclePluginImpl.class",
 
-    "com/fs/starfarer/loading/scripts/"
+    "com/fs/starfarer/loading/scripts/",
+    "com/fs/starfarer/loading/ShipHullSpreadsheetLoader.class",
+    "com/fs/starfarer/loading/WeaponSpreadsheetLoader.class",
+    "com/fs/starfarer/loading/FighterWingSpreadsheetLoader.class"
   ],
 
   "blocked_jar_strings": [],


### PR DESCRIPTION
### 변경 사항

, , 를 에 추가.

이 클래스들은 CSV 컬럼명을 문자열 리터럴로 직접 조회 키로 사용( 등)합니다. 번역 시 조회 키가 변경되어 값이 0으로 읽히는 버그를 수정합니다.

**증상:** 게임 내 모든 선박의 무장 포인트(OP)가 0으로 표시됨.