### PR TITLE
fix(exclusions): 시뮬레이션 ESC 메뉴 버그 수정

### DIFF
--- a/patches/exclusions.json
+++ b/patches/exclusions.json
@@ -31,7 +31,9 @@
     "com/fs/starfarer/combat/CombatMain.class"
   ],
 
-  "blocked_jar_strings": [],
+  "blocked_jar_strings": [
+    "run combat simulator"
+  ],
 
   "blocked_strings": []
 }


### PR DESCRIPTION
## 변경 내용

`run combat simulator` 세션 키를 `blocked_jar_strings`에 추가.

### 원인
- `command/J.class`, `coreui/refit/Q.class`는 blocked_classes 미포함 → 키가 번역됨
- `CombatEngine.isSimulation()`은 blocked이라 영어 키로 containsKey → 불일치
- isSimulation() 항상 false → 시뮬레이션에서 캠페인 종료 메뉴 표시

### 수정
blocked_jar_strings에 추가 (두 클래스 모두 번역 필요 UI 문자열 보유)