### PR TITLE
feat(patcher): class_trans.json 클래스별 핀포인트 번역 기능

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 | **번역 사전 (공통)** | `kr_work/patches/common.json` | 주 사전 (커밋 대상) |
 | **번역 사전 (api 전용)** | `kr_work/patches/api_jar.json` | api JAR 전용 (커밋 대상) |
 | **번역 사전 (obf 전용)** | `kr_work/patches/obf_jar.json` | obf JAR 전용 (커밋 대상) |
+| **클래스별 핀포인트 번역** | `kr_work/patches/class_trans.json` | 특정 클래스에서만 적용되는 번역 (커밋 대상) |
 | **전역 패치 제외 목록** | `kr_work/patches/exclusions.json` | blocked_classes + blocked_strings (커밋 대상) |
 | **상수 풀 패칭 라이브러리** | `kr_work/scripts/patch_utils.py` | patch_api_jar/patch_obf_jar/patch_mod_jar 공통 import |
 | **모드 JAR 패처** | `kr_work/scripts/patch_mod_jar.py` | post_build 훅으로 자동 호출 |
@@ -36,7 +37,26 @@
 |------|------|------|
 | `translations.json` | 선택 | EN→KO 번역 사전. common.json보다 우선 적용. |
 | `exclusions.json` | 선택 | 모드 전용 제외 목록. 전역 exclusions.json과 합집합으로 적용. |
+| `class_trans.json` | 선택 | 모드 전용 클래스별 핀포인트 번역. 전역 class_trans.json과 병합 (클래스 단위 merge). |
 | `data/`, `graphics/` | 선택 | 파일 오버레이. build_mods.py가 output/mods/{id}/에 복사. |
+
+**번역 사전 확장 (class_trans.json):**
+
+전역 번역에 추가하기엔 런타임 키 오염 위험이 있는 짧은 연결어·비교어를 특정 클래스에서만 안전하게 번역:
+
+```json
+// patches/class_trans.json
+{
+  "com/fs/starfarer/api/impl/campaign/CoreReputationPlugin.class": {
+    " or better": " 이상",
+    " or worse": " 이하"
+  }
+}
+```
+
+- 전역 `class_trans.json` + 모드 전용 `patches/{mod_id}/class_trans.json` 병합
+- **우선순위**: class_trans > blocked_strings > 전역 사전 (가장 좁은 단위가 가장 높은 우선순위)
+- patch_api_jar.py / patch_obf_jar.py / patch_mod_jar.py 모두 자동 적용
 
 **exclusions.json 3단계 제외 원칙 (최소 적용 원칙):**
 
@@ -137,6 +157,30 @@ python build.py check
 # 2. 전체 재빌드 및 검증
 python build.py all
 ```
+
+### 클래스별 핀포인트 번역 추가
+
+전역 사전에 추가하기엔 ID 오염 위험이 있는 짧은 연결어·비교어:
+
+```bash
+# 1. api_src/에서 대상 클래스 컨텍스트 확인 (런타임 키로 사용되는지)
+#    python /d/Starsector/jre/bin/java -jar tools/cfr.jar \
+#      api_src/com/fs/.../TargetClass.java 2>/dev/null | grep " or better"
+
+# 2. patches/class_trans.json에 클래스 경로와 번역 추가
+# {
+#   "com/fs/starfarer/api/impl/campaign/TargetClass.class": {
+#     " or better": " 이상"
+#   }
+# }
+
+# 3. 재빌드 (JAR 재패치 필요)
+python build.py rebuild
+```
+
+핀포인트 번역 사용 시점:
+- 특정 클래스에서만 UI 문자열로 사용되고, 다른 클래스에서는 내부 ID로 사용될 수 있는 경우
+- `" or better"`, `" and "` 같이 전역 추가 시 오염 위험이 있는 짧은 연결어/비교어
 
 ### 전체 재현 테스트
 

--- a/TRANSLATION_NOTES.md
+++ b/TRANSLATION_NOTES.md
@@ -359,3 +359,72 @@ class TestSomething(BaseTestCase):
 ### 8-3. CRITICAL: DRM 안전 확인
 
 `test_drm_strings_intact` — `accidents/A.class`의 anti-piracy 문자열이 번역되지 않았는지 빌드마다 자동 확인함. 이 테스트가 실패하면 즉시 조치 필요.
+
+---
+
+## 9. 클래스별 핀포인트 번역 (class_trans.json)
+
+### 9-1. 개념과 사용 시점
+
+전역 번역 사전(`common.json`, `api_jar.json`)에 추가하기엔 런타임 키 오염 위험이 있는 짧은 연결어·비교어를 **특정 클래스에서만 안전하게 번역**하는 기능.
+
+**사용 시점:**
+- `" or better"`, `" and "` 같은 짧은 UI 연결어가 특정 클래스에서는 화면 출력용이지만, 다른 클래스에서는 내부 ID 비교에 사용될 수 있는 경우
+- 전역 사전에 추가하면 ID가 번역되어 런타임 오류가 발생하나, 특정 클래스에서는 안전하다고 확인된 경우
+
+### 9-2. 포맷
+
+```json
+// patches/class_trans.json
+{
+  "com/fs/starfarer/api/impl/campaign/CoreReputationPlugin.class": {
+    " or better": " 이상",
+    " or worse": " 이하",
+    " or higher": " 이상",
+    " or lower": " 이하"
+  },
+  "com/fs/starfarer/api/impl/campaign/intel/BaseIntelPlugin.class": {
+    " and ": " "
+  }
+}
+```
+
+- **키**: JAR 내 클래스 경로 (슬래시 구분, `.class` 포함)
+- **값**: `{원문: 번역}` 사전
+- 내부 클래스는 `OuterClass$InnerClass.class` 형태
+
+모드 전용: `patches/{mod_id}/class_trans.json` — 전역 class_trans와 클래스 단위로 병합 (모드 항목이 덮어씀)
+
+### 9-3. 우선순위
+
+```
+class_trans (가장 높음)
+  > blocked_strings (제외 규칙)
+  > blocked_jar_strings (제외 규칙)
+  > 전역 번역 사전 (common + api_jar/obf_jar)
+```
+
+`blocked_strings`에 등록된 문자열이라도 `class_trans.json`에 해당 클래스로 명시되면 번역된다. class_trans는 특정 상수 풀 항목에 대한 가장 좁고 확실한 지정이기 때문.
+
+### 9-4. 안전성 확인 절차
+
+핀포인트 번역 추가 전 반드시 확인:
+
+```bash
+# CFR로 대상 클래스 디컴파일하여 컨텍스트 확인
+/d/Starsector/jre/bin/java -jar tools/cfr.jar \
+  /d/Starsector/starsector-core/starfarer.api.jar \
+  --outputdir /tmp/cfr_out/ 2>/dev/null
+
+# 출력에서 해당 문자열 사용 패턴 확인
+grep -n "or better" /tmp/cfr_out/com/fs/starfarer/api/impl/campaign/CoreReputationPlugin.java
+```
+
+번역 안전한 패턴: `addPara(... + " or better" + ...)`, `setText(...)`, UI 렌더링 호출
+번역 금지 패턴: `if (x.equals(" or better"))`, `.get(" or better")` — ID 비교/조회
+
+### 9-5. 테스트
+
+`TestClassPinpointTranslation` (tests/test_jars.py):
+- `test_class_specific_applied`: 등록 클래스에 번역이 적용됐는지 확인
+- `test_class_specific_isolated`: 비등록 클래스에 같은 원문이 번역되지 않았는지 확인 (핀포인트 격리 보장)

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     "api_trans":    "./patches/api_jar.json",
     "obf_trans":    "./patches/obf_jar.json",
     "exclusions":   "./patches/exclusions.json",
+    "class_trans":  "./patches/class_trans.json",
     "output":       "./output",
     "output_core":  "./output/starsector-core",
     "output_mods":  "./output/mods",

--- a/patches/class_trans.json
+++ b/patches/class_trans.json
@@ -1,0 +1,22 @@
+{
+  "_comment": [
+    "클래스별 핀포인트 번역 사전 (patches/class_trans.json)",
+    "전역 사전에 추가하기엔 런타임 키 오염 위험이 있는 짧은 연결어·비교어를",
+    "특정 클래스에서만 안전하게 번역하기 위해 사용.",
+    "",
+    "포맷:",
+    "  { 'com/path/to/ClassName.class': { '영어 원문': '한국어 번역', ... }, ... }",
+    "",
+    "우선순위: class_trans > blocked_strings > blocked_jar_strings > 전역 사전",
+    "즉, 전역 blocked_strings에 있더라도 이 파일에 명시된 클래스에서는 번역됨."
+  ],
+  "com/fs/starfarer/api/impl/campaign/CoreReputationPlugin.class": {
+    " or better": " 이상",
+    " or worse": " 이하",
+    " or higher": " 이상",
+    " or lower": " 이하"
+  },
+  "com/fs/starfarer/api/impl/campaign/intel/BaseIntelPlugin.class": {
+    " and ": " "
+  }
+}

--- a/patches/exclusions.json.template
+++ b/patches/exclusions.json.template
@@ -64,7 +64,18 @@
     "",
     "  경고: 이 목록의 문자열은 번역 사전에 있어도 완전히 무시됨.",
     "    부작용을 최소화하려면 목록을 가능한 한 짧게 유지할 것.",
-    "    단순 ID 오염은 blocked_classes로 더 정밀하게 해결 가능한 경우가 많음."
+    "    단순 ID 오염은 blocked_classes로 더 정밀하게 해결 가능한 경우가 많음.",
+    "",
+    "────────────────────────────────────────────────────────────",
+    "별도 수단: patches/class_trans.json  (제외가 아닌 추가 수단)",
+    "────────────────────────────────────────────────────────────",
+    "  이 파일(exclusions.json)과 독립적으로 동작하는 번역 추가 수단.",
+    "  특정 클래스에서만 번역할 수 있는 짧은 연결어·비교어를 지정.",
+    "  형식: { 'com/path/ClassName.class': { '원문': '번역' } }",
+    "  우선순위: class_trans > blocked_strings > 전역 사전",
+    "  즉, blocked_strings에 등록된 문자열도 class_trans에서 명시하면 번역됨.",
+    "  자세한 내용: TRANSLATION_NOTES.md 9절 참고.",
+    "  모드 전용: patches/{mod_id}/class_trans.json"
   ],
 
   "blocked_classes": [

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -11,9 +11,9 @@
 | 스크립트 | 목적 | 입력 | 출력 | build.py 연동 |
 |----------|------|------|------|---------------|
 | `patch_utils.py` | Java .class 상수 풀 패칭 공유 라이브러리 | (라이브러리, 직접 실행 없음) | — | patch_api_jar/patch_obf_jar/patch_mod_jar 공통 import |
-| `patch_api_jar.py` | starfarer.api.jar 상수 풀 패치 (인메모리 ZIP) | `starfarer.api.jar.bak` + `patches/common.json` + `patches/api_jar.json` + `patches/exclusions.json` | `output/starsector-core/starfarer.api.jar` | `patch` 파이프라인 1단계 |
-| `patch_obf_jar.py` | starfarer_obf.jar 인메모리 패치 | `starfarer_obf.jar.bak` + `patches/common.json` + `patches/obf_jar.json` + `patches/exclusions.json` | `output/starsector-core/starfarer_obf.jar` | `patch` 파이프라인 2단계 |
-| `patch_mod_jar.py` | 범용 모드 JAR 상수 풀 패치 (post_build 훅) | `output/mods/{id}/{mod_jar}` + `patches/common.json` + `patches/{id}/translations.json` + `patches/exclusions.json` (전역) + `patches/{id}/exclusions.json` (모드 전용, 선택) | `output/mods/{id}/{mod_jar}` (in-place) | `build_mod` post_build 훅 |
+| `patch_api_jar.py` | starfarer.api.jar 상수 풀 패치 (인메모리 ZIP) | `starfarer.api.jar.bak` + `patches/common.json` + `patches/api_jar.json` + `patches/exclusions.json` + `patches/class_trans.json` | `output/starsector-core/starfarer.api.jar` | `patch` 파이프라인 1단계 |
+| `patch_obf_jar.py` | starfarer_obf.jar 인메모리 패치 | `starfarer_obf.jar.bak` + `patches/common.json` + `patches/obf_jar.json` + `patches/exclusions.json` + `patches/class_trans.json` | `output/starsector-core/starfarer_obf.jar` | `patch` 파이프라인 2단계 |
+| `patch_mod_jar.py` | 범용 모드 JAR 상수 풀 패치 (post_build 훅) | `output/mods/{id}/{mod_jar}` + `patches/common.json` + `patches/{id}/translations.json` + `patches/exclusions.json` (전역) + `patches/{id}/exclusions.json` (모드 전용, 선택) + `patches/class_trans.json` + `patches/{id}/class_trans.json` (모드 전용, 선택) | `output/mods/{id}/{mod_jar}` (in-place) | `build_mod` post_build 훅 |
 | `translate_nex_rules_options.py` | Nexerelin rules.csv options 컬럼 번역 (post_build 훅) | `output/mods/Nexerelin/data/campaign/rules.csv` + `patches/Nexerelin/translations.json` | rules.csv options 컬럼 in-place 번역 | `build_mod` post_build 훅 (Nexerelin 전용) |
 | `build_mods.py` | 게임 원본 모드 + patches/ 오버레이 → output/mods/ 빌드 | `game_mods/<id>/` + `patches/<id>/` + `patches/exclusions.json` | `output/mods/<id>/` | `build_mod` 파이프라인 |
 | `apply_mods.py` | output/mods/ → 게임 mods/ 동기화 | `output/mods/<id>/` | `game_mods/<id>/` | `apply` 파이프라인 |

--- a/scripts/patch_api_jar.py
+++ b/scripts/patch_api_jar.py
@@ -23,7 +23,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from patch_utils import load_config, load_exclusions, load_translations, patch_jar, resolve_path
+from patch_utils import (load_class_translations, load_config, load_exclusions,
+                         load_translations, patch_jar, resolve_path)
 
 
 def main():
@@ -55,10 +56,13 @@ def main():
     translations = load_translations(paths, 'api_trans')
     blocked_classes, blocked_strings, blocked_jar_strings = load_exclusions(paths)
     jar_blocked = blocked_strings | blocked_jar_strings
-    print(f"Loaded {len(translations)} translations (common + api)")
+    class_trans = load_class_translations(paths)
+    print(f"Loaded {len(translations)} translations (common + api)"
+          + (f", class_trans {len(class_trans)} 클래스" if class_trans else ""))
 
     os.makedirs(os.path.dirname(out_jar), exist_ok=True)
-    stats = patch_jar(bak_jar, out_jar, translations, blocked_classes, jar_blocked, "api")
+    stats = patch_jar(bak_jar, out_jar, translations, blocked_classes, jar_blocked,
+                      label="api", class_translations=class_trans)
 
     print(f"\nProcessed {stats['total']} class files")
     print(f"  Patched:   {stats['patched']}")

--- a/scripts/patch_mod_jar.py
+++ b/scripts/patch_mod_jar.py
@@ -36,8 +36,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from patch_utils import (load_config, load_exclusions, load_translations,
-                          patch_jar, resolve_path)
+from patch_utils import (load_class_translations, load_config, load_exclusions,
+                          load_translations, patch_jar, resolve_path)
 
 
 def main():
@@ -86,6 +86,9 @@ def main():
     blocked_classes, blocked_strings, blocked_jar_strings = load_exclusions(paths, mod_id)
     jar_blocked = blocked_strings | blocked_jar_strings
 
+    # 전역 + 모드 전용 class_translations 병합
+    class_trans = load_class_translations(paths, mod_id=mod_id)
+
     for jar_rel in jar_paths:
         jar_path = output_mods / mod_id / jar_rel
         if not jar_path.exists():
@@ -96,7 +99,8 @@ def main():
         stats = patch_jar(
             jar_path, jar_path,
             translations, blocked_classes, jar_blocked,
-            label=f"{mod_id}/{jar_rel}"
+            label=f"{mod_id}/{jar_rel}",
+            class_translations=class_trans if class_trans else None,
         )
         print(f"  [{mod_id}/{jar_rel}] 패치: {stats['patched']}/{stats['total']} 클래스"
               + (f", 오류: {stats['errors']}" if stats['errors'] else ""))

--- a/scripts/patch_obf_jar.py
+++ b/scripts/patch_obf_jar.py
@@ -23,7 +23,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from patch_utils import load_config, load_exclusions, load_translations, patch_jar, resolve_path
+from patch_utils import (load_class_translations, load_config, load_exclusions,
+                         load_translations, patch_jar, resolve_path)
 
 
 def main():
@@ -54,10 +55,13 @@ def main():
     translations = load_translations(paths, 'obf_trans')
     blocked_classes, blocked_strings, blocked_jar_strings = load_exclusions(paths)
     jar_blocked = blocked_strings | blocked_jar_strings
-    print(f"Loaded {len(translations)} translations (common + obf)")
+    class_trans = load_class_translations(paths)
+    print(f"Loaded {len(translations)} translations (common + obf)"
+          + (f", class_trans {len(class_trans)} 클래스" if class_trans else ""))
 
     os.makedirs(os.path.dirname(out_jar), exist_ok=True)
-    stats = patch_jar(bak_jar, out_jar, translations, blocked_classes, jar_blocked, "obf")
+    stats = patch_jar(bak_jar, out_jar, translations, blocked_classes, jar_blocked,
+                      label="obf", class_translations=class_trans)
 
     print(f"\nProcessed {stats['total']} class files")
     print(f"  Patched:   {stats['patched']}")

--- a/scripts/patch_utils.py
+++ b/scripts/patch_utils.py
@@ -11,7 +11,8 @@ patch_utils.py - Java .class 상수 풀 패칭 공유 라이브러리
     parse_constant_pool(data: bytes) -> tuple[list, int]
     rebuild_class(data: bytes, translations: dict) -> Optional[bytes]
     is_blocked_class(classname: str, blocked_classes: set) -> bool
-    patch_jar(src_jar, dst_jar, translations, blocked_classes, blocked_strings, label) -> dict
+    patch_jar(src_jar, dst_jar, translations, blocked_classes, blocked_strings, label,
+              class_translations) -> dict
 
 공개 API (설정/경로/제외목록):
     resolve_path(p, base=None) -> str
@@ -19,6 +20,7 @@ patch_utils.py - Java .class 상수 풀 패칭 공유 라이브러리
     load_exclusions_file(path) -> tuple[set, set, set]
     load_exclusions(paths, mod_id=None) -> tuple[set, set, set]
     load_translations(paths, *extra_keys) -> dict
+    load_class_translations(paths, mod_id=None) -> dict
 """
 
 import json
@@ -285,11 +287,16 @@ def patch_jar(
     blocked_classes: set,
     blocked_strings: set,
     label: str = "",
+    class_translations: dict = None,
 ) -> dict:
     """
     src_jar의 .class 파일에 translations를 적용해 dst_jar로 저장.
     blocked_strings는 사전에서 먼저 제거한 후 패치.
     src_jar == dst_jar인 경우(in-place) 임시 파일로 우회.
+
+    class_translations: dict[classname -> {src: tgt}] — 클래스별 핀포인트 번역.
+        해당 클래스에서만 적용되며, blocked_strings 필터링 후의 전역 사전과 병합됨.
+        class_translations 항목이 전역 사전을 덮어씀 (우선순위 최상).
 
     Returns:
         dict with keys: total, patched, errors
@@ -335,7 +342,14 @@ def patch_jar(
                 if is_blocked_class(info.filename, blocked_classes):
                     dst_zip.writestr(info, data)
                     continue
-                result = rebuild_class(data, effective_translations)
+                # 클래스별 핀포인트 번역: 전역 사전 + 해당 클래스 사전 병합
+                # class_translations 항목이 전역 사전보다 우선(덮어씀)
+                if class_translations and info.filename in class_translations:
+                    cls_trans = {**effective_translations,
+                                 **class_translations[info.filename]}
+                else:
+                    cls_trans = effective_translations
+                result = rebuild_class(data, cls_trans)
                 if result is not None:
                     dst_zip.writestr(info, result)
                     patched += 1
@@ -423,4 +437,35 @@ def load_translations(paths: dict, *extra_keys: str) -> dict:
         if p and Path(p).exists():
             with open(p, encoding='utf-8') as f:
                 result.update(json.load(f))
+    return result
+
+
+def load_class_translations(paths: dict, mod_id: str = None) -> dict:
+    """
+    patches/class_trans.json [+ patches/{mod_id}/class_trans.json] 로드.
+
+    반환: dict[classname -> {src: tgt}]
+        - 키: JAR 내 클래스 경로 (슬래시 구분, .class 포함)
+        - 값: {원문: 번역} 사전
+
+    mod_id 지정 시 전역 class_trans에 모드 전용 class_trans를 병합.
+    모드 전용 항목이 전역 항목의 동일 클래스 항목을 덮어씀 (클래스 단위 merge).
+    """
+    result = {}
+    p = resolve_path(paths.get('class_trans', ''))
+    if p and Path(p).exists():
+        with open(p, encoding='utf-8') as f:
+            data = json.load(f)
+        # _comment 등 메타 키 제외 (.class로 끝나는 키만 포함)
+        result.update({k: v for k, v in data.items() if k.endswith('.class')})
+
+    if mod_id:
+        patches = Path(resolve_path(paths.get('patches', '')))
+        mp = patches / mod_id / 'class_trans.json'
+        if mp.exists():
+            with open(mp, encoding='utf-8') as f:
+                for cls, trans in json.load(f).items():
+                    if cls.endswith('.class'):
+                        result.setdefault(cls, {}).update(trans)
+
     return result

--- a/tests/test_jars.py
+++ b/tests/test_jars.py
@@ -1,6 +1,9 @@
 """test_jars.py - JAR 번역 적용 + 제외 규칙 + DRM 안전 검증"""
 
+import json
+import struct
 import zipfile
+from pathlib import Path
 
 from base_test import BaseTestCase
 from helpers import get_string_literals, has_korean, jar_has_korean
@@ -95,6 +98,151 @@ class TestExclusionRules(BaseTestCase):
         self.assertFalse(
             failures,
             "blocked_class에 한국어 번역 발견:\n" + "\n".join(failures)
+        )
+
+
+class TestClassPinpointTranslation(BaseTestCase):
+    """class_trans.json 핀포인트 번역 기능 검증."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+        from patch_utils import resolve_path
+        cls._resolve_path = staticmethod(resolve_path)
+
+        class_trans_path = resolve_path(cls.paths.get('class_trans', ''))
+        cls.class_trans = {}
+        if class_trans_path:
+            p = Path(class_trans_path)
+            if p.exists():
+                with open(p, encoding='utf-8') as f:
+                    data = json.load(f)
+                    # _comment 키 제외
+                    cls.class_trans = {k: v for k, v in data.items()
+                                       if not k.startswith('_')}
+
+    def _find_jar_for_class(self, classname):
+        """주어진 클래스가 있는 출력 JAR 경로를 반환 (없으면 None)."""
+        for jar_path in [
+            self.output_core / 'starfarer.api.jar',
+            self.output_core / 'starfarer_obf.jar',
+        ]:
+            if not jar_path.exists():
+                continue
+            with zipfile.ZipFile(jar_path) as z:
+                if classname in z.namelist():
+                    return jar_path
+        return None
+
+    def _load_global_keys(self):
+        """공통 + api + obf 전역 번역 사전의 원문 키 집합."""
+        keys = set(self.common_translations)
+        for trans_key in ('api_trans', 'obf_trans'):
+            p_str = self._resolve_path(self.paths.get(trans_key, ''))
+            if p_str:
+                p = Path(p_str)
+                if p.exists():
+                    with open(p, encoding='utf-8') as f:
+                        keys.update(json.load(f).keys())
+        return keys
+
+    def test_class_specific_applied(self):
+        """class_trans.json 등록 클래스에 번역이 적용됐는지 확인."""
+        if not self.class_trans:
+            self.skipTest("class_trans.json 비어있거나 없음")
+
+        failures = []
+        skipped = []
+        for classname, trans in self.class_trans.items():
+            jar_path = self._find_jar_for_class(classname)
+            if jar_path is None:
+                skipped.append(classname)
+                continue
+            try:
+                strings = get_string_literals(jar_path, classname)
+            except Exception as e:
+                failures.append(f"{classname}: 파싱 오류 ({e})")
+                continue
+            for src, tgt in trans.items():
+                if tgt not in strings:
+                    failures.append(
+                        f"{classname}: '{src}' → '{tgt}' 번역 미적용"
+                        f" (현재 strings: {sorted(s for s in strings if has_korean(s))[:3]})"
+                    )
+
+        if skipped:
+            print(f"  [skip] 출력 JAR에 없는 클래스 {len(skipped)}개: {skipped}")
+        self.assertFalse(
+            failures,
+            "class_trans 번역이 적용되지 않음:\n" + "\n".join(failures)
+        )
+
+    def test_class_specific_isolated(self):
+        """class_trans 전용 원문이 비등록 클래스에서 번역되지 않았는지 확인."""
+        if not self.class_trans:
+            self.skipTest("class_trans.json 비어있거나 없음")
+
+        global_keys = self._load_global_keys()
+        registered_classes = set(self.class_trans.keys())
+
+        # 전역 사전에 없는 class_trans 원문만 → 이것들만 핀포인트 의미 있음
+        # {src: tgt} (첫 번째 등록 클래스 기준)
+        pinpoint_trans = {}
+        for trans in self.class_trans.values():
+            for src, tgt in trans.items():
+                if src not in global_keys and src not in pinpoint_trans:
+                    pinpoint_trans[src] = tgt
+
+        if not pinpoint_trans:
+            self.skipTest(
+                "class_trans의 모든 원문이 이미 전역 사전에 있음 — 격리 테스트 해당 없음"
+            )
+
+        failures = []
+        for jar_path in [
+            self.output_core / 'starfarer.api.jar',
+            self.output_core / 'starfarer_obf.jar',
+        ]:
+            if not jar_path.exists():
+                continue
+
+            with zipfile.ZipFile(jar_path) as z:
+                all_classes = [n for n in z.namelist()
+                               if n.endswith('.class') and n not in registered_classes]
+                data_map = {}
+                for name in all_classes:
+                    try:
+                        data_map[name] = z.read(name)
+                    except Exception:
+                        pass
+
+            # 비등록 클래스에서 src가 있고 tgt도 있으면 격리 실패
+            from patch_utils import decode_java_utf8, parse_constant_pool
+            for name, data in data_map.items():
+                try:
+                    entries, _ = parse_constant_pool(data)
+                except Exception:
+                    continue
+                str_indices = {struct.unpack_from('>H', v)[0]
+                               for tag, v in (e for e in entries if e) if tag == 8}
+                strings = set()
+                for i, entry in enumerate(entries):
+                    if entry and entry[0] == 1 and i in str_indices:
+                        try:
+                            strings.add(decode_java_utf8(entry[1]))
+                        except Exception:
+                            pass
+                for src, tgt in pinpoint_trans.items():
+                    if src in strings and tgt in strings:
+                        failures.append(
+                            f"[격리 실패] {name}: '{src}' → '{tgt}' 적용됨 (비등록 클래스)"
+                        )
+
+        self.assertFalse(
+            failures,
+            "class_trans 번역이 비등록 클래스에 누출됨:\n" + "\n".join(failures)
         )
 
 


### PR DESCRIPTION
## 변경사항

- `patches/class_trans.json` 신규: 클래스 단위 핀포인트 번역 사전
- `patch_utils.py`: `load_class_translations()` 추가, `patch_jar()` `class_translations` 파라미터 확장
- `patch_api_jar.py`, `patch_obf_jar.py`, `patch_mod_jar.py`: class_trans 로드 및 전달
- `config.json`: `class_trans` 경로 키 추가
- `tests/test_jars.py`: `TestClassPinpointTranslation` 테스트 추가
- 문서 업데이트 (AGENTS.md, TRANSLATION_NOTES.md, SCRIPTS.md)

## 배경

`" or better"`, `" or worse"` 등 짧은 UI 연결어가 전역 번역 시 런타임 키를 파괴할 위험이 있어 번역 불가였음. 클래스 단위 핀포인트 번역으로 안전하게 적용 가능.